### PR TITLE
Fix for XDomainRequest

### DIFF
--- a/request.js
+++ b/request.js
@@ -60,6 +60,8 @@
 
         if(window.XDomainRequest){
             request = new XDomainRequest();
+            request.onprogress = function(){ };
+            request.ontimeout = function(){ };
         }else if(window.ActiveXObject){
             request = new ActiveXObject('Microsoft.XMLHTTP'); 
         }else if(window.XMLHttpRequest){

--- a/request.js
+++ b/request.js
@@ -70,7 +70,7 @@
             if(query) url += ((url.indexOf('?') > -1) ? '&' : '?') + utils.toQuery(query);
             request.open(method, (url.indexOf('http') > -1) ? url : protocol+url, true);
             request.onload = function(){
-                if(request.statusText === 'OK' && request.status === 200){
+                if((request.statusText === 'OK' && request.status === 200) || typeof request.statusText === 'undefined'){
                     methods.success.apply(methods, utils.parse(request));
                     methods.always.apply();    
                 } else {


### PR DESCRIPTION
[XDomainRequest](http://msdn.microsoft.com/en-us/library/ie/cc288060%28v=vs.85%29.aspx) doesn't have the properties `.statusText` and `.status`, so IE is sending all the requests to the error callback.
The solution is to check if `.statusText` is undefined (that may indicate XDomainRequest), and in that case, go to the success callback.

You can totally ignore this (I'm running the hotfix on gulp). Hope you're enjoying your holidays :smile: .
